### PR TITLE
Alps 1296 - Share current Camera & View parameters

### DIFF
--- a/Share/manifest.json
+++ b/Share/manifest.json
@@ -1,0 +1,39 @@
+{
+    "uid": "org.forgejs.share",
+    "name": "Share",
+    "slug": "share",
+    "version": "1.0.0",
+    "versionName": "share 1.0.0",
+    "description": "Create an url with camera parameters for view sharing",
+
+    "author":
+    {
+        "name": "GoPro",
+        "website": "https://forgejs.org"
+    },
+
+    "licence": "Apache 2",
+
+    "viewer":
+    {
+        "min": "0.9.0",
+        "max": "0.9.5"
+    },
+
+    "options":
+    {
+
+    },
+
+    "events":
+    {
+
+    },
+
+    "sources":
+    [
+        "src/Share.js"
+    ],
+
+    "constructor": "ForgePlugins.Share"
+}

--- a/Share/manifest.json
+++ b/Share/manifest.json
@@ -22,12 +22,13 @@
 
     "options":
     {
+        "yaw": true,
+        "pitch": true,
+        "roll": false,
+        "fov": true,
+        "view": true,
 
-    },
-
-    "events":
-    {
-
+        "format": "short"
     },
 
     "sources":

--- a/Share/manifest.json
+++ b/Share/manifest.json
@@ -28,7 +28,8 @@
         "fov": true,
         "view": true,
 
-        "format": "short"
+        "format": "short",
+        "precision": 2
     },
 
     "sources":

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -50,6 +50,7 @@ ForgePlugins.Share.prototype = {
         var hash = history.generateHash(this.viewer.story.scene, false);
 
         var format = this.plugin.options.format;
+        var precision = this.plugin.options.precision;
 
         if (format === "short")
         {
@@ -58,19 +59,19 @@ ForgePlugins.Share.prototype = {
 
         if (this.plugin.options.yaw === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "yaw=" + camera.yaw.toFixed(2) : camera.yaw.toFixed(2) + "y,");
+            hash += (format !== "short" ? this._paramSuffix + "yaw=" + camera.yaw.toFixed(precision) : camera.yaw.toFixed(precision) + "y,");
         }
         if (this.plugin.options.pitch === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "pitch=" + camera.pitch.toFixed(2) : camera.pitch.toFixed(2) + "p,");
+            hash += (format !== "short" ? this._paramSuffix + "pitch=" + camera.pitch.toFixed(precision) : camera.pitch.toFixed(precision) + "p,");
         }
         if (this.plugin.options.roll === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "roll=" + camera.roll.toFixed(2) : camera.roll.toFixed(2) + "r,");
+            hash += (format !== "short" ? this._paramSuffix + "roll=" + camera.roll.toFixed(precision) : camera.roll.toFixed(precision) + "r,");
         }
         if (this.plugin.options.fov === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "fov=" + camera.fov.toFixed(2) : camera.fov.toFixed(2) + "f,");
+            hash += (format !== "short" ? this._paramSuffix + "fov=" + camera.fov.toFixed(precision) : camera.fov.toFixed(precision) + "f,");
         }
         if (this.plugin.options.view === true)
         {

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -58,23 +58,29 @@ ForgePlugins.Share.prototype = {
 
         if (this.plugin.options.yaw === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "yaw=" : "y") + camera.yaw.toFixed(2);
+            hash += (format !== "short" ? this._paramSuffix + "yaw=" + camera.yaw.toFixed(2) : camera.yaw.toFixed(2) + "y,");
         }
         if (this.plugin.options.pitch === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "pitch=" : "p") + camera.pitch.toFixed(2);
+            hash += (format !== "short" ? this._paramSuffix + "pitch=" + camera.pitch.toFixed(2) : camera.pitch.toFixed(2) + "p,");
         }
         if (this.plugin.options.roll === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "roll=" : "r") + camera.roll.toFixed(2);
+            hash += (format !== "short" ? this._paramSuffix + "roll=" + camera.roll.toFixed(2) : camera.roll.toFixed(2) + "r,");
         }
         if (this.plugin.options.fov === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "fov=" : "f") + camera.fov.toFixed(2);
+            hash += (format !== "short" ? this._paramSuffix + "fov=" + camera.fov.toFixed(2) : camera.fov.toFixed(2) + "f,");
         }
         if (this.plugin.options.view === true)
         {
-            hash += (format !== "short" ? this._paramSuffix + "view=" : "v") + this.viewer.view.type;
+            hash += (format !== "short" ? this._paramSuffix + "view=" + this.viewer.view.type : this.viewer.view.type + "v,");
+        }
+
+        // remove last comma
+        if (format === "short" && hash.substr(-1) === ",")
+        {
+            hash = hash.slice(0, -1);
         }
 
         return hash;
@@ -91,40 +97,40 @@ ForgePlugins.Share.prototype = {
 
         if(hashParameters !== null)
         {
-            // short URL
+            // hash for short URL
             var hash = FORGE.URL.parse()["hash"];
 
-            // verify the short parameters and add them as hashParameters
-            var re = /&?(y|p|r|f|v)([0-9\-.]+|rectilinear|gopro|flat)/gi;
+            // verify and apply the short URL parameters
+            var re = /&?([0-9\-.]+|rectilinear|gopro|flat)(y|p|r|f|v)\,?/gi;
             var rr;
             while ((rr = re.exec(hash)) !== null)
             {
-                if (typeof rr[2] === "string")
+                if (typeof rr[1] === "string")
                 {
-                    if (rr[1] === "y" && this.plugin.options.yaw === true)
+                    if (rr[2] === "y" && this.plugin.options.yaw === true)
                     {
-                        this.viewer.camera.yaw = Number(rr[2]);
+                        this.viewer.camera.yaw = Number(rr[1]);
                     }
-                    if (rr[1] === "p" && this.plugin.options.pitch === true)
+                    if (rr[2] === "p" && this.plugin.options.pitch === true)
                     {
-                        this.viewer.camera.pitch = Number(rr[2]);
+                        this.viewer.camera.pitch = Number(rr[1]);
                     }
-                    if (rr[1] === "r" && this.plugin.options.roll === true)
+                    if (rr[2] === "r" && this.plugin.options.roll === true)
                     {
-                        this.viewer.camera.roll = Number(rr[2]);
+                        this.viewer.camera.roll = Number(rr[1]);
                     }
-                    if (rr[1] === "f" && this.plugin.options.fov === true)
+                    if (rr[2] === "f" && this.plugin.options.fov === true)
                     {
-                        this.viewer.camera.fov = Number(rr[2]);
+                        this.viewer.camera.fov = Number(rr[1]);
                     }
-                    if (rr[1] === "v"&& this.plugin.options.view === true)
+                    if (rr[2] === "v"&& this.plugin.options.view === true)
                     {
-                        this.viewer.view.type = rr[2].toLowerCase();
+                        this.viewer.view.type = rr[1].toLowerCase();
                     }
                 }
             }
 
-            // normal URL
+            // verify and apply the normal URL parameters
             if(typeof hashParameters.view === "string" && this.plugin.options.view === true)
             {
                 this.viewer.view.type = hashParameters.view.toLowerCase();

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -88,7 +88,32 @@ ForgePlugins.Share.prototype = {
 
     updateURL: function()
     {
-        window.location.hash = this.createURL();
+        var url = this.createURL();
+
+        if (window.history.replaceState)
+        {
+            var scene = this.viewer.story.scene;
+            var state =
+            {
+                "viewer":
+                {
+                    uid: this.viewer.uid
+                },
+
+                "scene":
+                {
+                    uid: scene.uid
+                },
+
+                "locale": this.viewer.i18n.locale
+            }
+
+            window.history.replaceState(state, scene.name, url);
+        }
+        else
+        {
+            window.location.hash = url;
+        }
     },
 
     _sceneLoadCompleteHandler: function()
@@ -97,6 +122,32 @@ ForgePlugins.Share.prototype = {
 
         if(hashParameters !== null)
         {
+            // verify and apply the normal URL parameters
+            if(typeof hashParameters.view === "string" && this.plugin.options.view === true)
+            {
+                this.viewer.view.type = hashParameters.view.toLowerCase();
+            }
+
+            if(typeof hashParameters.yaw === "string" && this.plugin.options.yaw === true)
+            {
+                this.viewer.camera.yaw = Number(hashParameters.yaw);
+            }
+
+            if(typeof hashParameters.pitch === "string" && this.plugin.options.pitch === true)
+            {
+                this.viewer.camera.pitch = Number(hashParameters.pitch);
+            }
+
+            if(typeof hashParameters.roll === "string" && this.plugin.options.roll === true)
+            {
+                this.viewer.camera.roll = Number(hashParameters.roll);
+            }
+
+            if(typeof hashParameters.fov === "string" && this.plugin.options.fov === true)
+            {
+                this.viewer.camera.fov = Number(hashParameters.fov);
+            }
+
             // hash for short URL
             var hash = FORGE.URL.parse()["hash"];
 
@@ -128,32 +179,6 @@ ForgePlugins.Share.prototype = {
                         this.viewer.view.type = rr[1].toLowerCase();
                     }
                 }
-            }
-
-            // verify and apply the normal URL parameters
-            if(typeof hashParameters.view === "string" && this.plugin.options.view === true)
-            {
-                this.viewer.view.type = hashParameters.view.toLowerCase();
-            }
-
-            if(typeof hashParameters.yaw === "string" && this.plugin.options.yaw === true)
-            {
-                this.viewer.camera.yaw = Number(hashParameters.yaw);
-            }
-
-            if(typeof hashParameters.pitch === "string" && this.plugin.options.pitch === true)
-            {
-                this.viewer.camera.pitch = Number(hashParameters.pitch);
-            }
-
-            if(typeof hashParameters.roll === "string" && this.plugin.options.roll === true)
-            {
-                this.viewer.camera.roll = Number(hashParameters.roll);
-            }
-
-            if(typeof hashParameters.fov === "string" && this.plugin.options.fov === true)
-            {
-                this.viewer.camera.fov = Number(hashParameters.fov);
             }
         }
 

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -1,0 +1,91 @@
+var ForgePlugins = ForgePlugins || {};
+
+
+ForgePlugins.Share = function()
+{
+    this._timer = null;
+
+    this._loop = null;
+};
+
+ForgePlugins.Share.prototype = {
+
+    /**
+     * The boot function
+     */
+    boot: function()
+    {
+        this.viewer.story.onSceneLoadComplete.add(this._sceneLoadCompleteHandler, this);
+        this._sceneLoadCompleteHandler();
+    },
+
+    /**
+     * Destroy the button.
+     */
+    destroy: function()
+    {
+        this._timer.destroy();
+        this._timer = null;
+    },
+
+    createURL: function()
+    {
+        var camera = this.viewer.camera;
+        var history = this.viewer.history;
+
+        var hash = history.generateHash(this.viewer.story.scene, false);
+        hash += "&yaw=" + camera.yaw.toFixed(0);
+        hash += "&pitch=" + camera.pitch.toFixed(0);
+        hash += "&roll=" + camera.roll.toFixed(0);
+        hash += "&fov=" + camera.fov.toFixed(0);
+        hash += "&view=" + this.viewer.view.type;
+
+        return hash;
+    },
+
+    updateURL: function()
+    {
+        window.location.hash = this.createURL();
+    },
+
+    _sceneLoadCompleteHandler: function()
+    {
+        var hashParameters = FORGE.URL.parse()["hashParameters"];
+
+        if(hashParameters !== null)
+        {
+            if(typeof hashParameters.view === "string")
+            {
+                this.viewer.view.type = hashParameters.view;
+            }
+
+            if(typeof hashParameters.yaw === "string")
+            {
+                this.viewer.camera.yaw = Number(hashParameters.yaw);
+            }
+
+            if(typeof hashParameters.pitch === "string")
+            {
+                this.viewer.camera.pitch = Number(hashParameters.pitch);
+            }
+
+            if(typeof hashParameters.roll === "string")
+            {
+                this.viewer.camera.roll = Number(hashParameters.roll);
+            }
+
+            if(typeof hashParameters.fov === "string")
+            {
+                this.viewer.camera.fov = Number(hashParameters.fov);
+            }
+        }
+
+        if(this._timer === null)
+        {
+            this._timer = this.viewer.clock.create(false);
+            this._loop = this._timer.create(1000, true, Infinity, this.updateURL, this);
+            this._timer.start();
+        }
+    }
+
+};

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -181,6 +181,8 @@ ForgePlugins.Share.prototype = {
                     }
                 }
             }
+
+            this.viewer.view.current.updateUniforms();
         }
 
         if (this._timer === null)

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -121,32 +121,32 @@ ForgePlugins.Share.prototype = {
     {
         var hashParameters = FORGE.URL.parse()["hashParameters"];
 
-        if(hashParameters !== null)
+        if (hashParameters !== null)
         {
             // verify and apply the normal URL parameters
-            if(typeof hashParameters.view === "string" && this.plugin.options.view === true)
+            if (typeof hashParameters.view === "string" && this.plugin.options.view === true)
             {
                 this.viewer.view.type = hashParameters.view.toLowerCase();
             }
 
-            if(typeof hashParameters.yaw === "string" && this.plugin.options.yaw === true)
+            if (typeof hashParameters.fov === "string" && this.plugin.options.fov === true)
+            {
+                this.viewer.camera.fov = Number(hashParameters.fov);
+            }
+
+            if (typeof hashParameters.yaw === "string" && this.plugin.options.yaw === true)
             {
                 this.viewer.camera.yaw = Number(hashParameters.yaw);
             }
 
-            if(typeof hashParameters.pitch === "string" && this.plugin.options.pitch === true)
+            if (typeof hashParameters.pitch === "string" && this.plugin.options.pitch === true)
             {
                 this.viewer.camera.pitch = Number(hashParameters.pitch);
             }
 
-            if(typeof hashParameters.roll === "string" && this.plugin.options.roll === true)
+            if (typeof hashParameters.roll === "string" && this.plugin.options.roll === true)
             {
                 this.viewer.camera.roll = Number(hashParameters.roll);
-            }
-
-            if(typeof hashParameters.fov === "string" && this.plugin.options.fov === true)
-            {
-                this.viewer.camera.fov = Number(hashParameters.fov);
             }
 
             // hash for short URL
@@ -159,6 +159,14 @@ ForgePlugins.Share.prototype = {
             {
                 if (typeof rr[1] === "string")
                 {
+                    if (rr[2] === "v"&& this.plugin.options.view === true)
+                    {
+                        this.viewer.view.type = rr[1].toLowerCase();
+                    }
+                    if (rr[2] === "f" && this.plugin.options.fov === true)
+                    {
+                        this.viewer.camera.fov = Number(rr[1]);
+                    }
                     if (rr[2] === "y" && this.plugin.options.yaw === true)
                     {
                         this.viewer.camera.yaw = Number(rr[1]);
@@ -171,19 +179,11 @@ ForgePlugins.Share.prototype = {
                     {
                         this.viewer.camera.roll = Number(rr[1]);
                     }
-                    if (rr[2] === "f" && this.plugin.options.fov === true)
-                    {
-                        this.viewer.camera.fov = Number(rr[1]);
-                    }
-                    if (rr[2] === "v"&& this.plugin.options.view === true)
-                    {
-                        this.viewer.view.type = rr[1].toLowerCase();
-                    }
                 }
             }
         }
 
-        if(this._timer === null)
+        if (this._timer === null)
         {
             this._timer = this.viewer.clock.create(false);
             this._loop = this._timer.create(1000, true, Infinity, this.updateURL, this);


### PR DESCRIPTION
Add a plugin to manage Camera & View parameters (get & set into History).

- ability to manage a set of parameter into view, fov, roll, pitch and yaw values.
- ability to manage normal camera & view querystring parameters as:
`&yaw=-32.02&pitch=6.03&roll=0.00&fov=90.00&view=rectilinear`
- ability to manage short camera & view parameters as:
`&-32.02y,6.03p,0.00r,90.00f,rectilinearv`

**Please note that History must be activated prior to this plugin add.**