### PR TITLE
Telemetry plugins as hotspot texture

### DIFF
--- a/Accelerometer/manifest.json
+++ b/Accelerometer/manifest.json
@@ -64,7 +64,9 @@
             "fontWeight": "normal"
         },
 
-        "source": "media"
+        "source": "media",
+
+        "dom": true
     },
 
     "data":

--- a/Accelerometer/src/Accelerometer.js
+++ b/Accelerometer/src/Accelerometer.js
@@ -55,10 +55,7 @@ ForgePlugins.Accelerometer.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        if (this.plugin.options.dom === false)
-        {
-            this.plugin.notifyInstanceReady();
-        }
+        this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -67,6 +64,15 @@ ForgePlugins.Accelerometer.prototype = {
      */
     reset: function()
     {
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
+        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
+
         this._video = null;
         this._setupVideo();
     },
@@ -271,13 +277,17 @@ ForgePlugins.Accelerometer.prototype = {
      */
     destroy: function()
     {
-        this._canvas.destroy();
-        this._canvas = null;
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
 
+        this._canvas.destroy();
+
+        this._canvas = null;
+        this._trail = null;
         this._video = null;
         this._data = null;
-
-        this._trail = null;
     }
 };
 

--- a/Accelerometer/src/Accelerometer.js
+++ b/Accelerometer/src/Accelerometer.js
@@ -44,13 +44,18 @@ ForgePlugins.Accelerometer.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        this.plugin.container.addChild(this._canvas);
+        if (this.plugin.options.dom === true)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
 
         // Setup the reference to the video
         this._setupVideo();
 
         // Load the JSON data
         this._loadJsonData();
+
+        // this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -256,3 +261,14 @@ ForgePlugins.Accelerometer.prototype = {
         this._trail = null;
     }
 };
+
+/**
+ * Return the canvas, to use it as texture.
+ */
+Object.defineProperty(ForgePlugins.Accelerometer.prototype, "texture",
+{
+    get: function()
+    {
+        return this._canvas;
+    }
+});

--- a/Accelerometer/src/Accelerometer.js
+++ b/Accelerometer/src/Accelerometer.js
@@ -44,9 +44,11 @@ ForgePlugins.Accelerometer.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        if (this.plugin.options.dom === true)
+        this.plugin.container.addChild(this._canvas);
+
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.addChild(this._canvas);
+            this.hide();
         }
 
         // Setup the reference to the video
@@ -64,13 +66,13 @@ ForgePlugins.Accelerometer.prototype = {
      */
     reset: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.removeChild(this._canvas);
+            this.hide();
         }
-        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        else
         {
-            this.plugin.container.addChild(this._canvas);
+            this.show();
         }
 
         this._video = null;
@@ -261,7 +263,10 @@ ForgePlugins.Accelerometer.prototype = {
      */
     show: function()
     {
-        this._canvas.show();
+        if (this._canvas !== null)
+        {
+            this._canvas.show();
+        }
     },
 
     /**
@@ -269,7 +274,10 @@ ForgePlugins.Accelerometer.prototype = {
      */
     hide: function()
     {
-        this._canvas.hide();
+        if (this._canvas !== null)
+        {
+            this._canvas.hide();
+        }
     },
 
     /**
@@ -277,10 +285,7 @@ ForgePlugins.Accelerometer.prototype = {
      */
     destroy: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
-        {
-            this.plugin.container.removeChild(this._canvas);
-        }
+        this.plugin.container.removeChild(this._canvas);
 
         this._canvas.destroy();
 

--- a/Accelerometer/src/Accelerometer.js
+++ b/Accelerometer/src/Accelerometer.js
@@ -55,7 +55,10 @@ ForgePlugins.Accelerometer.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        // this.plugin.notifyInstanceReady();
+        if (this.plugin.options.dom === false)
+        {
+            this.plugin.notifyInstanceReady();
+        }
     },
 
     /**
@@ -149,7 +152,7 @@ ForgePlugins.Accelerometer.prototype = {
      */
     update: function()
     {
-        if (this._data === null)
+        if (this._data === null || this._canvas === null)
         {
             return;
         }
@@ -245,6 +248,22 @@ ForgePlugins.Accelerometer.prototype = {
         {
             // waiting next frame to get the canvas not yet created
         }
+    },
+
+    /**
+     * Show
+     */
+    show: function()
+    {
+        this._canvas.show();
+    },
+
+    /**
+     * Hide
+     */
+    hide: function()
+    {
+        this._canvas.hide();
     },
 
     /**

--- a/Altimeter/manifest.json
+++ b/Altimeter/manifest.json
@@ -49,7 +49,9 @@
             "fontWeight": "normal"
         },
 
-        "source": "media"
+        "source": "media",
+
+        "dom": true
     },
 
     "data":

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -42,10 +42,7 @@ ForgePlugins.Altimeter.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        if (this.plugin.options.dom === false)
-        {
-            this.plugin.notifyInstanceReady();
-        }
+        this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -54,6 +51,15 @@ ForgePlugins.Altimeter.prototype = {
      */
     reset: function()
     {
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
+        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
+
         this._video = null;
         this._setupVideo();
     },
@@ -202,11 +208,16 @@ ForgePlugins.Altimeter.prototype = {
      */
     destroy: function()
     {
-        this._video = null;
-        this._data = null;
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
 
         this._canvas.destroy();
+
         this._canvas = null;
+        this._video = null;
+        this._data = null;
     }
 };
 

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -31,13 +31,18 @@ ForgePlugins.Altimeter.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        this.plugin.container.addChild(this._canvas);
+        if (this.plugin.options.dom === true)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
 
         // Setup the reference to the video
         this._setupVideo();
 
         // Load the JSON data
         this._loadJsonData();
+
+        // this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -174,6 +179,22 @@ ForgePlugins.Altimeter.prototype = {
     },
 
     /**
+     * Show
+     */
+    show: function()
+    {
+        this._canvas.show();
+    },
+
+    /**
+     * Hide
+     */
+    hide: function()
+    {
+        this._canvas.hide();
+    },
+
+    /**
      * Destroy routine
      */
     destroy: function()
@@ -184,3 +205,14 @@ ForgePlugins.Altimeter.prototype = {
         this._canvas.destroy();
     }
 };
+
+/**
+ * Return the canvas, to use it as texture.
+ */
+Object.defineProperty(ForgePlugins.Altimeter.prototype, "texture",
+{
+    get: function()
+    {
+        return this._canvas;
+    }
+});

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -206,6 +206,7 @@ ForgePlugins.Altimeter.prototype = {
         this._data = null;
 
         this._canvas.destroy();
+        this._canvas = null;
     }
 };
 

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -31,9 +31,11 @@ ForgePlugins.Altimeter.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        if (this.plugin.options.dom === true)
+        this.plugin.container.addChild(this._canvas);
+
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.addChild(this._canvas);
+            this.hide();
         }
 
         // Setup the reference to the video
@@ -51,13 +53,13 @@ ForgePlugins.Altimeter.prototype = {
      */
     reset: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.removeChild(this._canvas);
+            this.hide();
         }
-        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        else
         {
-            this.plugin.container.addChild(this._canvas);
+            this.show();
         }
 
         this._video = null;
@@ -192,7 +194,10 @@ ForgePlugins.Altimeter.prototype = {
      */
     show: function()
     {
-        this._canvas.show();
+        if (this._canvas !== null)
+        {
+            this._canvas.show();
+        }
     },
 
     /**
@@ -200,7 +205,10 @@ ForgePlugins.Altimeter.prototype = {
      */
     hide: function()
     {
-        this._canvas.hide();
+        if (this._canvas !== null)
+        {
+            this._canvas.hide();
+        }
     },
 
     /**
@@ -208,10 +216,7 @@ ForgePlugins.Altimeter.prototype = {
      */
     destroy: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
-        {
-            this.plugin.container.removeChild(this._canvas);
-        }
+        this.plugin.container.removeChild(this._canvas);
 
         this._canvas.destroy();
 

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -42,7 +42,10 @@ ForgePlugins.Altimeter.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        // this.plugin.notifyInstanceReady();
+        if (this.plugin.options.dom === false)
+        {
+            this.plugin.notifyInstanceReady();
+        }
     },
 
     /**
@@ -121,7 +124,7 @@ ForgePlugins.Altimeter.prototype = {
      */
     update: function()
     {
-        if (this._data === null)
+        if (this._data === null || this._canvas === null)
         {
             return;
         }

--- a/Compass/manifest.json
+++ b/Compass/manifest.json
@@ -66,7 +66,9 @@
             "fontWeight": "normal"
         },
 
-        "source": "media"
+        "source": "media",
+
+        "dom": true
     },
 
     "data":

--- a/Compass/src/Compass.js
+++ b/Compass/src/Compass.js
@@ -47,10 +47,7 @@ ForgePlugins.Compass.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        if (this.plugin.options.dom === false)
-        {
-            this.plugin.notifyInstanceReady();
-        }
+        this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -59,6 +56,15 @@ ForgePlugins.Compass.prototype = {
      */
     reset: function()
     {
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
+        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
+
         this._video = null;
         this._setupVideo();
     },
@@ -213,11 +219,15 @@ ForgePlugins.Compass.prototype = {
      */
     destroy: function()
     {
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
+
         this._canvas.destroy();
+
         this._canvas = null;
-
         this._video = null;
-
         this._data = null;
     }
 };

--- a/Compass/src/Compass.js
+++ b/Compass/src/Compass.js
@@ -36,9 +36,11 @@ ForgePlugins.Compass.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        if (this.plugin.options.dom === true)
+        this.plugin.container.addChild(this._canvas);
+
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.addChild(this._canvas);
+            this.hide();
         }
 
         // Setup the reference to the video
@@ -56,13 +58,13 @@ ForgePlugins.Compass.prototype = {
      */
     reset: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.removeChild(this._canvas);
+            this.hide();
         }
-        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        else
         {
-            this.plugin.container.addChild(this._canvas);
+            this.show();
         }
 
         this._video = null;
@@ -203,7 +205,10 @@ ForgePlugins.Compass.prototype = {
      */
     show: function()
     {
-        this._canvas.show();
+        if (this._canvas !== null)
+        {
+            this._canvas.show();
+        }
     },
 
     /**
@@ -211,7 +216,10 @@ ForgePlugins.Compass.prototype = {
      */
     hide: function()
     {
-        this._canvas.hide();
+        if (this._canvas !== null)
+        {
+            this._canvas.hide();
+        }
     },
 
     /**
@@ -219,10 +227,7 @@ ForgePlugins.Compass.prototype = {
      */
     destroy: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
-        {
-            this.plugin.container.removeChild(this._canvas);
-        }
+        this.plugin.container.removeChild(this._canvas);
 
         this._canvas.destroy();
 

--- a/Compass/src/Compass.js
+++ b/Compass/src/Compass.js
@@ -36,13 +36,18 @@ ForgePlugins.Compass.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        this.plugin.container.addChild(this._canvas);
+        if (this.plugin.options.dom === true)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
 
         // Setup the reference to the video
         this._setupVideo();
 
         // Load the JSON data
         this._loadJsonData();
+
+        // this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -197,3 +202,14 @@ ForgePlugins.Compass.prototype = {
         this._data = null;
     }
 };
+
+/**
+ * Return the canvas, to use it as texture.
+ */
+Object.defineProperty(ForgePlugins.Compass.prototype, "texture",
+{
+    get: function()
+    {
+        return this._canvas;
+    }
+});

--- a/Compass/src/Compass.js
+++ b/Compass/src/Compass.js
@@ -47,7 +47,10 @@ ForgePlugins.Compass.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        // this.plugin.notifyInstanceReady();
+        if (this.plugin.options.dom === false)
+        {
+            this.plugin.notifyInstanceReady();
+        }
     },
 
     /**
@@ -126,7 +129,7 @@ ForgePlugins.Compass.prototype = {
      */
     update: function()
     {
-        if (this._data === null)
+        if (this._data === null || this._canvas === null)
         {
             return;
         }
@@ -187,6 +190,22 @@ ForgePlugins.Compass.prototype = {
         {
             // waiting next frame to get the canvas not yet created
         }
+    },
+
+    /**
+     * Show
+     */
+    show: function()
+    {
+        this._canvas.show();
+    },
+
+    /**
+     * Hide
+     */
+    hide: function()
+    {
+        this._canvas.hide();
     },
 
     /**

--- a/GoogleMaps/src/GoogleMaps.js
+++ b/GoogleMaps/src/GoogleMaps.js
@@ -53,7 +53,15 @@ ForgePlugins.GoogleMaps.prototype = {
         // Setup the reference to the video
         this._setupVideo();
 
-        this._loadGoogleMapScript();
+        if (typeof google === "undefined" || !("maps" in google))
+        {
+            this._loadGoogleMapScript();
+        }
+        else if (typeof google !== "undefined" && "maps" in google)
+        {
+            this._createMap();
+            this._loadGpx();
+        }
     },
 
     /**
@@ -80,13 +88,16 @@ ForgePlugins.GoogleMaps.prototype = {
         this._clearVideo();
         this._setupVideo();
 
-        if (typeof google !== "undefined")
+        if (typeof google !== "undefined" && "maps" in google)
         {
             this._loadGpx();
         }
     },
 
-    _setupVideo: function(video)
+    /**
+     * Setup a video as media or plugin
+     */
+    _setupVideo: function()
     {
         if (this.plugin.options.source === "media")
         {
@@ -110,6 +121,9 @@ ForgePlugins.GoogleMaps.prototype = {
         }
     },
 
+    /**
+     * Clean the video object
+     */
     _clearVideo: function()
     {
         this._video = null;
@@ -132,7 +146,9 @@ ForgePlugins.GoogleMaps.prototype = {
         }
     },
 
-    // Actions to do on Google Maps script loaded
+    /**
+     * Actions to do on Google Maps script loaded
+     */
     _googleMapScriptLoadComplete: function()
     {
         this._createMap();
@@ -467,7 +483,10 @@ ForgePlugins.GoogleMaps.prototype = {
      */
     destroy: function()
     {
-        google.maps.event.clearListeners(this._poly, 'click');
+        if (typeof google !== "undefined" && "maps" in google && this._poly !== null)
+        {
+            google.maps.event.clearListeners(this._poly, 'click');
+        }
 
         this._video = null;
         this._container = null;

--- a/Share/src/Share.js
+++ b/Share/src/Share.js
@@ -159,7 +159,7 @@ ForgePlugins.Share.prototype = {
             {
                 if (typeof rr[1] === "string")
                 {
-                    if (rr[2] === "v"&& this.plugin.options.view === true)
+                    if (rr[2] === "v" && this.plugin.options.view === true)
                     {
                         this.viewer.view.type = rr[1].toLowerCase();
                     }

--- a/Speedometer/manifest.json
+++ b/Speedometer/manifest.json
@@ -73,7 +73,9 @@
             "fontWeight": "normal"
         },
 
-        "source": "media"
+        "source": "media",
+
+        "dom": true
     },
 
     "data":

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -42,13 +42,18 @@ ForgePlugins.Speedometer.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        this.plugin.container.addChild(this._canvas);
+        if (this.plugin.options.dom === true)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
 
         // Setup the reference to the video
         this._setupVideo();
 
         // Load the JSON data
         this._loadJsonData();
+
+        // this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -263,3 +268,14 @@ ForgePlugins.Speedometer.prototype = {
         this._canvas.destroy();
     }
 };
+
+/**
+ * Return the canvas, to use it as texture.
+ */
+Object.defineProperty(ForgePlugins.Speedometer.prototype, "texture",
+{
+    get: function()
+    {
+        return this._canvas;
+    }
+});

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -53,7 +53,10 @@ ForgePlugins.Speedometer.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        // this.plugin.notifyInstanceReady();
+        if (this.plugin.options.dom === false)
+        {
+            this.plugin.notifyInstanceReady();
+        }
     },
 
     /**
@@ -174,7 +177,7 @@ ForgePlugins.Speedometer.prototype = {
      */
     update: function()
     {
-        if (this._data === null)
+        if (this._data === null || this._canvas === null)
         {
             return;
         }
@@ -254,6 +257,22 @@ ForgePlugins.Speedometer.prototype = {
         {
             // waiting next frame to get the canvas not yet created
         }
+    },
+
+    /**
+     * Show
+     */
+    show: function()
+    {
+        this._canvas.show();
+    },
+
+    /**
+     * Hide
+     */
+    hide: function()
+    {
+        this._canvas.hide();
     },
 
     /**

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -53,10 +53,7 @@ ForgePlugins.Speedometer.prototype = {
         // Load the JSON data
         this._loadJsonData();
 
-        if (this.plugin.options.dom === false)
-        {
-            this.plugin.notifyInstanceReady();
-        }
+        this.plugin.notifyInstanceReady();
     },
 
     /**
@@ -65,6 +62,15 @@ ForgePlugins.Speedometer.prototype = {
      */
     reset: function()
     {
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
+        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        {
+            this.plugin.container.addChild(this._canvas);
+        }
+
         this._video = null;
         this._setupVideo();
     },
@@ -280,12 +286,17 @@ ForgePlugins.Speedometer.prototype = {
      */
     destroy: function()
     {
-        this._video = null;
-        this._data = null;
-        this._graduation = null;
+        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        {
+            this.plugin.container.removeChild(this._canvas);
+        }
 
         this._canvas.destroy();
+
         this._canvas = null;
+        this._graduation = null;
+        this._video = null;
+        this._data = null;
     }
 };
 

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -42,9 +42,11 @@ ForgePlugins.Speedometer.prototype = {
         this._canvas.right = this.plugin.options.right;
         this._canvas.bottom = this.plugin.options.bottom;
 
-        if (this.plugin.options.dom === true)
+        this.plugin.container.addChild(this._canvas);
+
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.addChild(this._canvas);
+            this.hide();
         }
 
         // Setup the reference to the video
@@ -62,13 +64,13 @@ ForgePlugins.Speedometer.prototype = {
      */
     reset: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
+        if (this.plugin.options.dom === false)
         {
-            this.plugin.container.removeChild(this._canvas);
+            this.hide();
         }
-        else if (this.plugin.options.dom === true && this.plugin.container.hasChild(this._canvas) === false)
+        else
         {
-            this.plugin.container.addChild(this._canvas);
+            this.show();
         }
 
         this._video = null;
@@ -270,7 +272,10 @@ ForgePlugins.Speedometer.prototype = {
      */
     show: function()
     {
-        this._canvas.show();
+        if (this._canvas !== null)
+        {
+            this._canvas.show();
+        }
     },
 
     /**
@@ -278,7 +283,10 @@ ForgePlugins.Speedometer.prototype = {
      */
     hide: function()
     {
-        this._canvas.hide();
+        if (this._canvas !== null)
+        {
+            this._canvas.hide();
+        }
     },
 
     /**
@@ -286,10 +294,7 @@ ForgePlugins.Speedometer.prototype = {
      */
     destroy: function()
     {
-        if (this.plugin.options.dom === false && this.plugin.container.hasChild(this._canvas) === true)
-        {
-            this.plugin.container.removeChild(this._canvas);
-        }
+        this.plugin.container.removeChild(this._canvas);
 
         this._canvas.destroy();
 

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -285,6 +285,7 @@ ForgePlugins.Speedometer.prototype = {
         this._graduation = null;
 
         this._canvas.destroy();
+        this._canvas = null;
     }
 };
 


### PR DESCRIPTION
Telemetry plugins can be rendered as texture for hotspots.
The `dom` property can be set to force the rendering into DOM or as texture.
`show` and `hide` methods have been added also.