### PR TITLE
GoogleMaps plugin: avoid reload of the current gpx track loaded

### DIFF
--- a/Accelerometer/src/Accelerometer.js
+++ b/Accelerometer/src/Accelerometer.js
@@ -61,6 +61,15 @@ ForgePlugins.Accelerometer.prototype = {
      */
     reset: function()
     {
+        this._size = Math.min(this.plugin.options.width, this.plugin.options.height);
+
+        this._canvas.width = this.plugin.options.width;
+        this._canvas.height = this.plugin.options.height;
+        this._canvas.top = this.plugin.options.top;
+        this._canvas.left = this.plugin.options.left;
+        this._canvas.right = this.plugin.options.right;
+        this._canvas.bottom = this.plugin.options.bottom;
+
         if (this.plugin.options.visible === false)
         {
             this.hide();
@@ -72,6 +81,13 @@ ForgePlugins.Accelerometer.prototype = {
 
         this._video = null;
         this._setupVideo();
+
+        var suffix = this.plugin.data.json.split("/");
+        suffix = suffix[suffix.length - 1];
+        if (this.viewer.cache.has("json", this.plugin.uid + "_json") === false || this.plugin.data.json !== this.viewer.cache.get("json", this.plugin.uid + suffix + "_json").url)
+        {
+            this._loadJsonData();
+        }
     },
 
     /**
@@ -110,7 +126,9 @@ ForgePlugins.Accelerometer.prototype = {
 
         if (typeof json === "string" && json !== "")
         {
-            this.viewer.load.json(this.plugin.uid + "_json", json, this._jsonLoadComplete.bind(this), this);
+            var suffix = json.split("/");
+            suffix = suffix[suffix.length - 1];
+            this.viewer.load.json(this.plugin.uid + suffix +  "_json", json, this._jsonLoadComplete.bind(this), this);
         }
         else
         {

--- a/Altimeter/src/Altimeter.js
+++ b/Altimeter/src/Altimeter.js
@@ -53,6 +53,13 @@ ForgePlugins.Altimeter.prototype = {
      */
     reset: function()
     {
+        this._canvas.width = this.plugin.options.width;
+        this._canvas.height = this.plugin.options.height;
+        this._canvas.top = this.plugin.options.top;
+        this._canvas.left = this.plugin.options.left;
+        this._canvas.right = this.plugin.options.right;
+        this._canvas.bottom = this.plugin.options.bottom;
+
         if (this.plugin.options.visible === false)
         {
             this.hide();
@@ -64,6 +71,14 @@ ForgePlugins.Altimeter.prototype = {
 
         this._video = null;
         this._setupVideo();
+
+
+        var suffix = this.plugin.data.json.split("/");
+        suffix = suffix[suffix.length - 1];
+        if (this.viewer.cache.has("json", this.plugin.uid + "_json") === false || this.plugin.data.json !== this.viewer.cache.get("json", this.plugin.uid + suffix + "_json").url)
+        {
+            this._loadJsonData();
+        }
     },
 
     /**
@@ -102,7 +117,9 @@ ForgePlugins.Altimeter.prototype = {
 
         if (typeof json === "string" && json !== "")
         {
-            this.viewer.load.json(this.plugin.uid + "_json", json, this._jsonLoadComplete.bind(this), this);
+            var suffix = json.split("/");
+            suffix = suffix[suffix.length - 1];
+            this.viewer.load.json(this.plugin.uid + suffix +  "_json", json, this._jsonLoadComplete.bind(this), this);
         }
         else
         {

--- a/Compass/src/Compass.js
+++ b/Compass/src/Compass.js
@@ -58,6 +58,15 @@ ForgePlugins.Compass.prototype = {
      */
     reset: function()
     {
+        this._size = Math.min(this.plugin.options.width, this.plugin.options.height);
+
+        this._canvas.width = this.plugin.options.width;
+        this._canvas.height = this.plugin.options.height;
+        this._canvas.top = this.plugin.options.top;
+        this._canvas.left = this.plugin.options.left;
+        this._canvas.right = this.plugin.options.right;
+        this._canvas.bottom = this.plugin.options.bottom;
+
         if (this.plugin.options.visible === false)
         {
             this.hide();
@@ -69,6 +78,13 @@ ForgePlugins.Compass.prototype = {
 
         this._video = null;
         this._setupVideo();
+
+        var suffix = this.plugin.data.json.split("/");
+        suffix = suffix[suffix.length - 1];
+        if (this.viewer.cache.has("json", this.plugin.uid + "_json") === false || this.plugin.data.json !== this.viewer.cache.get("json", this.plugin.uid + suffix + "_json").url)
+        {
+            this._loadJsonData();
+        }
     },
 
     /**
@@ -107,7 +123,9 @@ ForgePlugins.Compass.prototype = {
 
         if (typeof json === "string" && json !== "")
         {
-            this.viewer.load.json(this.plugin.uid + "_json", json, this._jsonLoadComplete.bind(this), this);
+            var suffix = json.split("/");
+            suffix = suffix[suffix.length - 1];
+            this.viewer.load.json(this.plugin.uid + suffix +  "_json", json, this._jsonLoadComplete.bind(this), this);
         }
         else
         {

--- a/GoogleMaps/src/GoogleMaps.js
+++ b/GoogleMaps/src/GoogleMaps.js
@@ -88,7 +88,7 @@ ForgePlugins.GoogleMaps.prototype = {
         this._clearVideo();
         this._setupVideo();
 
-        if (typeof google !== "undefined" && "maps" in google)
+        if (typeof google !== "undefined" && "maps" in google && (this.viewer.cache.has("xml", "googlemaps_gpx") === false || this.plugin.data.gpx !== this.viewer.cache.get("xml", "googlemaps_gpx").url))
         {
             this._loadGpx();
         }

--- a/GoogleMaps/src/GoogleMaps.js
+++ b/GoogleMaps/src/GoogleMaps.js
@@ -88,7 +88,7 @@ ForgePlugins.GoogleMaps.prototype = {
         this._clearVideo();
         this._setupVideo();
 
-        if (typeof google !== "undefined" && "maps" in google && (this.viewer.cache.has("xml", "googlemaps_gpx") === false || this.plugin.data.gpx !== this.viewer.cache.get("xml", "googlemaps_gpx").url))
+        if (typeof google !== "undefined" && "maps" in google && (this.viewer.cache.has("xml", this.plugin.uid + "_gpx") === false || this.plugin.data.gpx !== this.viewer.cache.get("xml", this.plugin.uid + "_gpx").url))
         {
             this._loadGpx();
         }

--- a/GoogleMaps/src/GoogleMaps.js
+++ b/GoogleMaps/src/GoogleMaps.js
@@ -57,11 +57,6 @@ ForgePlugins.GoogleMaps.prototype = {
         {
             this._loadGoogleMapScript();
         }
-        else if (typeof google !== "undefined" && "maps" in google)
-        {
-            this._createMap();
-            this._loadGpx();
-        }
     },
 
     /**
@@ -88,8 +83,9 @@ ForgePlugins.GoogleMaps.prototype = {
         this._clearVideo();
         this._setupVideo();
 
-        if (typeof google !== "undefined" && "maps" in google && (this.viewer.cache.has("xml", this.plugin.uid + "_gpx") === false || this.plugin.data.gpx !== this.viewer.cache.get("xml", this.plugin.uid + "_gpx").url))
+        if (typeof google !== "undefined" && "maps" in google)
         {
+            this._createMap();
             this._loadGpx();
         }
     },

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -18,7 +18,7 @@ ForgePlugins.Speedometer = function()
     this._size = 0;
 
     // Defined lines on json loading
-    this._lines = [];
+    this._lines = null;
 
     // Multiplicator for the value on the arc
     this._multiplicator = 0;
@@ -145,6 +145,7 @@ ForgePlugins.Speedometer.prototype = {
     _jsonLoadComplete: function(file)
     {
         this._data = file.data;
+        this._lines = [];
 
         var max = 0;
         this._data.data.forEach(function(e)
@@ -186,7 +187,7 @@ ForgePlugins.Speedometer.prototype = {
             this._lines[i] = i * res[0];
         }
 
-        this._multiplicator = (0.21 - 0.01 * (this._lines.length - 1)) / 2;
+        this._multiplicator = (0.21 - 0.01 * (this._lines.length - 1)) / (res[0] / 5);
     },
 
     /**

--- a/Speedometer/src/Speedometer.js
+++ b/Speedometer/src/Speedometer.js
@@ -64,6 +64,15 @@ ForgePlugins.Speedometer.prototype = {
      */
     reset: function()
     {
+        this._size = Math.min(this.plugin.options.width, this.plugin.options.height);
+
+        this._canvas.width = this.plugin.options.width;
+        this._canvas.height = this.plugin.options.height;
+        this._canvas.top = this.plugin.options.top;
+        this._canvas.left = this.plugin.options.left;
+        this._canvas.right = this.plugin.options.right;
+        this._canvas.bottom = this.plugin.options.bottom;
+
         if (this.plugin.options.visible === false)
         {
             this.hide();
@@ -75,6 +84,13 @@ ForgePlugins.Speedometer.prototype = {
 
         this._video = null;
         this._setupVideo();
+
+        var suffix = this.plugin.data.json.split("/");
+        suffix = suffix[suffix.length - 1];
+        if (this.viewer.cache.has("json", this.plugin.uid + "_json") === false || this.plugin.data.json !== this.viewer.cache.get("json", this.plugin.uid + suffix + "_json").url)
+        {
+            this._loadJsonData();
+        }
     },
 
     /**
@@ -113,7 +129,9 @@ ForgePlugins.Speedometer.prototype = {
 
         if (typeof json === "string" && json !== "")
         {
-            this.viewer.load.json(this.plugin.uid + "_json", json, this._jsonLoadComplete.bind(this), this);
+            var suffix = json.split("/");
+            suffix = suffix[suffix.length - 1];
+            this.viewer.load.json(this.plugin.uid + suffix +  "_json", json, this._jsonLoadComplete.bind(this), this);
         }
         else
         {


### PR DESCRIPTION
The reload of the same gpx file can cause issues when using reset="true" in configuration file